### PR TITLE
Change Paas to Application Platform

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -13,7 +13,7 @@ Welcome to the SUSE CAP Sandbox!
 If you would like to skip the introduction and just get logged in and start playing around, [click here](/quickstart/)
 {{</callout>}}
 
-## Key Developer Benefits to Platform as a Service
+## Key Developer Benefits to an Application Platform
 
 Imagine you just got a new (employer provided) laptop. First thing you do is slap your favorite OS on it and then the fun begins. You have to install your favorite editor or IDE, compilers, libraries, debug tools and what have you. Fast forward a few hours and you're slowly getting to a point where your new tool becomes usable. Couple of weeks later something in your tool-chain breaks and you have to spend time to fix it. Updates need to be made, dependencies to be considered and managed and so on. Bottom line is, you need to invest a certain amount of your valuable time into building and maintaining your development environment, your workbench so to speak. And this time gets taken away from the time you have to do actually productive things, i.e. write code. 
 
@@ -21,9 +21,9 @@ Recent surveys have shown, that developers actually only spend about one third o
 
 And so far we have just talked about an individual developer. Imagine your teammates doing the same thing. Which not only causes the time spent on maintaining dev environments to multiply across your team, it also makes everybody end up with a different environment - even if they install exactly the same set of software. There will be version differences of some sort. Security patches come every day. New library versions get published every day. Generally speaking, there's always the possibility that code that runs on your machine doesn't run on your colleague's machine. So additional time needs to be spent on integration work. 
 
-Platform as a Service addresses all those problems. 
+An Application Platform addresses all those problems. 
 
-Looking at it from an individual developer's point of view, PaaS makes it possible (but by no means necessary) to avoid composing and maintaining a local build toolchain, since the platform takes care of building your code at deployment time. The only thing you really need locally is an editor or an IDE. You can then push your code to your PaaS cluster and the rest will be taken care of by the platform. 
+Looking at it from an individual developer's point of view, an Application Platform makes it possible (but by no means necessary) to avoid composing and maintaining a local build toolchain, since the platform takes care of building your code at deployment time. The only thing you really need locally is an editor or an IDE. You can then push your code to your PaaS cluster and the rest will be taken care of by the platform. 
 
 ### Build Packs
 In case of Cloud Foundry, there is a concept called [build packs](https://docs.cloudfoundry.org/buildpacks/), which standardizes your build environment. Cloud Foundry will inspect your code directory when you push it, and automatically detect the right build pack to use (you can manually override that if you want). In a nutshell, CF tries to detect which programming language you use and if your code makes any assumptions on required build tools like Maven or Gradle. 
@@ -33,7 +33,7 @@ This concept becomes even more beneficial when it comes to harmonizing developme
 
 ### Ecosystem
 
-Another advantage of Platform as a Service is that it can rid a developer to maintain adjacent components as part of the test tool-chain. The platform operator usually offers a number of services such as databases, search and analytics engines, etc. Imagine you want to use a database in your app. Normally you would have to install and configure that database yourself. With a PaaS, your platform operator can offer readily available database instances as services that you can bind to your app. So the only thing you need to worry about is the API calls to the database interface in your code. 
+Another advantage of an Application Platform is that it can rid a developer to maintain adjacent components as part of the test tool-chain. The platform operator usually offers a number of services such as databases, search and analytics engines, etc. Imagine you want to use a database in your app. Normally you would have to install and configure that database yourself. With an Application Platform, your platform operator can offer readily available database instances as services that you can bind to your app. So the only thing you need to worry about is the API calls to the database interface in your code. 
 
 ### Services
 
@@ -43,7 +43,7 @@ This set of features gives a really easy way to connect your application to exte
 
 ### Autoscaling
 
-Yet another benefit of PaaS is that it helps you avoid writing certain kinds of code that you don't want to write. For example, platforms usually have built-in load balancers and autoscaling capabilities so that the platform can launch additional app instances automatically - you don't have to write the code that does this anymore. This is a very complex topic though, and if you want to dive more into those aspects...
+Yet another benefit of Application Platforms is that they help you avoid writing certain kinds of code that you don't want to write. For example, platforms usually have built-in load balancers and autoscaling capabilities so that the platform can launch additional app instances automatically - you don't have to write the code that does this and handles the corresponding state information anymore. This is a very complex topic though, and if you want to dive more into those aspects...
   
 ## Stratos vs Command Line
 


### PR DESCRIPTION
Changing language: "Application Platform" instead of "Platform as a Service" 